### PR TITLE
Fixes #7: Make RandomAccess always open

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 
 use std::io;
 
-/// Methods that need to be implemented for the `RandomAccess` struct.
-pub trait RandomAccessMethods {
+/// The `RandomAccess` trait allows for reading from and writing to a
+/// randomly accessible storage of bytes.
+pub trait RandomAccess {
   /// An error.
   type Error;
 
@@ -30,49 +31,4 @@ pub trait RandomAccessMethods {
 
   /// Delete a sequence of bytes at an offset from the backend.
   fn del(&mut self, offset: usize, length: usize) -> Result<(), Self::Error>;
-}
-
-/// Create a random access instance.
-#[derive(Debug)]
-pub struct RandomAccess<T> {
-  handler: T,
-}
-
-impl<T> RandomAccess<T>
-where
-  T: RandomAccessMethods,
-{
-  /// Create a new `RandomAccess` instance.
-  pub fn new(handler: T) -> RandomAccess<T> {
-    Self { handler }
-  }
-
-  /// Write bytes at an offset. Calls out to `RandomAccessMethods::write`.
-  pub fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), T::Error> {
-    T::write(&mut self.handler, offset, data)
-  }
-
-  /// Read bytes from an offset. Calls out to `RandomAccessMethods::read`.
-  pub fn read(
-    &mut self,
-    offset: usize,
-    length: usize,
-  ) -> Result<Vec<u8>, T::Error> {
-    T::read(&mut self.handler, offset, length)
-  }
-
-  /// Read bytes to a vector. Calls out to `RandomAccessMethods::read_to_writer`
-  pub fn read_to_writer(
-    &mut self,
-    offset: usize,
-    length: usize,
-    buf: &mut impl io::Write,
-  ) -> Result<(), T::Error> {
-    T::read_to_writer(&mut self.handler, offset, length, buf)
-  }
-
-  /// Delete bytes from an offset. Calls out to `RandomAccessMethods::del`.
-  pub fn del(&mut self, offset: usize, length: usize) -> Result<(), T::Error> {
-    T::del(&mut self.handler, offset, length)
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@ pub trait RandomAccessMethods {
   /// An error.
   type Error;
 
-  /// Open the backend.
-  fn open(&mut self) -> Result<(), Self::Error>;
-
   /// Write bytes at an offset to the backend.
   fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), Self::Error>;
 
@@ -38,8 +35,6 @@ pub trait RandomAccessMethods {
 /// Create a random access instance.
 #[derive(Debug)]
 pub struct RandomAccess<T> {
-  /// Check whether or not the file has been opened.
-  pub opened: bool,
   handler: T,
 }
 
@@ -49,18 +44,11 @@ where
 {
   /// Create a new `RandomAccess` instance.
   pub fn new(handler: T) -> RandomAccess<T> {
-    Self {
-      handler,
-      opened: false,
-    }
+    Self { handler }
   }
 
   /// Write bytes at an offset. Calls out to `RandomAccessMethods::write`.
   pub fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), T::Error> {
-    if !self.opened {
-      T::open(&mut self.handler)?;
-      self.opened = true;
-    }
     T::write(&mut self.handler, offset, data)
   }
 
@@ -70,10 +58,6 @@ where
     offset: usize,
     length: usize,
   ) -> Result<Vec<u8>, T::Error> {
-    if !self.opened {
-      T::open(&mut self.handler)?;
-      self.opened = true;
-    }
     T::read(&mut self.handler, offset, length)
   }
 
@@ -84,19 +68,11 @@ where
     length: usize,
     buf: &mut impl io::Write,
   ) -> Result<(), T::Error> {
-    if !self.opened {
-      T::open(&mut self.handler)?;
-      self.opened = true;
-    }
     T::read_to_writer(&mut self.handler, offset, length, buf)
   }
 
   /// Delete bytes from an offset. Calls out to `RandomAccessMethods::del`.
   pub fn del(&mut self, offset: usize, length: usize) -> Result<(), T::Error> {
-    if !self.opened {
-      T::open(&mut self.handler)?;
-      self.opened = true;
-    }
     T::del(&mut self.handler, offset, length)
   }
 }


### PR DESCRIPTION
This PR removes the `open()` method and the now redundant `RandomAccess` struct.

This does not follow exactly #7 as there is no new struct/trait for the unopened state. It turns out that adding that would complicate things for no benefit IMO.

## Checklist

- [x] documentation is changed or added

## Context
#7 

## Semver Changes
Minor
