### PR TITLE
Fix missing &mut in len() causing Sync compilation problems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub trait RandomAccess {
   async fn truncate(&mut self, length: u64) -> Result<(), Self::Error>;
 
   /// Get the size of the storage in bytes.
-  async fn len(&self) -> Result<u64, Self::Error>;
+  async fn len(&mut self) -> Result<u64, Self::Error>;
 
   /// Whether the storage is empty.
   /// For some storage backends it may be cheaper to calculate whether the


### PR DESCRIPTION
**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🐛 

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
When attempting to compile code that calls `len()` compilation fails with Sync problems. The README.md example already has the `&mut` (https://github.com/datrs/random-access-storage/blob/master/README.md?plain=1#L54-L56), but it was missing in the code. This likely got overlooked because no project yet used the function. Note that `&mut` seems unnecessary but is not: similarly `is_empty()` is also `&mut`.

## Semver Changes
This will need any project that implements RandomAccessStorage to change so it is a breaking change. Hence 5.0.0.

## Related PRs

* https://github.com/datrs/random-access-memory/pull/36
* https://github.com/datrs/random-access-disk/pull/47