### PR TITLE
Fix missing &mut in len(), remove read_to_writer, RandomAccessError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/random-access-storage"
 documentation = "https://docs.rs/random-access-storage"
 description = "Abstract interface to implement random-access instances."
-authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>", "Timo Tiuraniemi <timo.tiuraniemi@iki.fi>"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.63"
+async-trait = "0.1"
+thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.24"
-futures-io = "0.3.4"
+async-trait = "0.1.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random-access-storage"
-version = "4.0.0"
+version = "5.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/random-access-storage"
 documentation = "https://docs.rs/random-access-storage"

--- a/README.md
+++ b/README.md
@@ -7,64 +7,13 @@ Abstract interface to implement random-access instances.
 - [Documentation][8]
 - [Crate][2]
 
-## Why?
-This module forms a shared interface for reading and writing bytes to
-different backends. By having a shared interface, it means implementations
-can easily be swapped, depending on the environment.
-
-## Usage
-```rust
-use random_access_storage::{RandomAccessMethods, RandomAccess};
-use async_trait::async_trait;
-
-struct S;
-#[async_trait]
-impl RandomAccessMethods for S {
-  type Error = std::io::Error;
-
-  async fn open(&mut self) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-
-  async fn write(&mut self, offset: u64, data: &[u8]) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-
-  async fn read(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, Self::Error> {
-    unimplemented!();
-  }
-
-  async fn del(&mut self, offset: u64, length: u64) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-
-  async fn truncate(&mut self, length: u64) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-
-  async fn len(&mut self) -> Result<u64, Self::Error> {
-    unimplemented!();
-  }
-
-  async fn is_empty(&mut self) -> Result<bool, Self::Error> {
-    unimplemented!();
-  }
-
-  async fn sync_all(&mut self) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-}
-
-let _file = RandomAccess::new(S);
-```
-
 ## Installation
 ```sh
 $ cargo add random-access-storage
 ```
 
 ## See Also
-- [random-access-storage/random-access-storage](https://github.com/random-access-storage/random-access-storage)
+- Original Javascript [random-access-storage](https://github.com/random-access-storage/random-access-storage)
 
 ## License
 [MIT](./LICENSE-MIT) OR [Apache-2.0](./LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -34,15 +34,6 @@ impl RandomAccessMethods for S {
     unimplemented!();
   }
 
-  async fn read_to_writer(
-    &mut self,
-    offset: u64,
-    length: u64,
-    writer: &mut (impl futures::io::AsyncWriter + Send)
-  ) -> Result<(), Self::Error> {
-    unimplemented!();
-  }
-
   async fn del(&mut self, offset: u64, length: u64) -> Result<(), Self::Error> {
     unimplemented!();
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,91 @@
-#![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
+#![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-
+#![doc(test(attr(deny(warnings))))]
+//! # Abstract interface to implement random-access instances
+//!
+//! This crate defines the shared [RandomAccess] trait that makes it possible to create
+//! different backends for reading, writing and deleting bytes. With a shared interface,
+//! implementations can easily be swapped, depending on the needs and the environment.
+//!
+//! ## Known Implementations
+//!
+//! Full implementations of [RandomAccess] include:
+//!
+//! * [random-access-memory](https://docs.rs/random-access-memory) for in-memory storage
+//! * [random-access-disk](https://docs.rs/random-access-disk) for disk storage
+//!
+//! ## Examples
+//!
+//! Your own random-access backend can be implemented like this:
+//!
+//! ```
+//! use random_access_storage::{RandomAccess, RandomAccessError};
+//! use async_trait::async_trait;
+//!
+//! struct MyRandomAccess {
+//!   // Add fields here
+//! }
+//!
+//! #[async_trait]
+//! impl RandomAccess for MyRandomAccess {
+//!   async fn write(&mut self, _offset: u64, _data: &[u8]) -> Result<(), RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//
+//!   async fn read(&mut self, _offset: u64, _length: u64) -> Result<Vec<u8>, RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//!
+//!   async fn del(&mut self, _offset: u64, _length: u64) -> Result<(), RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//!
+//!   async fn truncate(&mut self, _length: u64) -> Result<(), RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//!
+//!   async fn len(&mut self) -> Result<u64, RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//!
+//!   async fn is_empty(&mut self) -> Result<bool, RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//!
+//!   async fn sync_all(&mut self) -> Result<(), RandomAccessError> {
+//!     unimplemented!();
+//!   }
+//! }
+//! ```
 use thiserror::Error;
 
+/// Error type for the [RandomAccess] trait methods.
 #[derive(Error, Debug)]
 pub enum RandomAccessError {
+  /// Given parameters are out of bounds.
   #[error("{} out of bounds. {} < {}{}",
           .end.as_ref().map_or_else(|| "Offset", |_| "Range"),
           .length,
           .offset,
           .end.as_ref().map_or_else(String::new, |end| format!("..{}", end)))]
   OutOfBounds {
+    /// Offset that was out of bounds
     offset: u64,
+    /// If it was a range that was out of bounds, the end of the range.
     end: Option<u64>,
+    /// The length in the implementation that was exceeded.
     length: u64,
   },
+  /// Unexpected [std::io::Error].
   #[error("Unrecoverable input/output error occured.{}{}",
           .return_code.as_ref().map_or_else(String::new, |rc| format!(" Return code: {}.", rc)),
           .context.as_ref().map_or_else(String::new, |ctx| format!(" Context: {}.", ctx)))]
   IO {
+    /// Optional system return code that caused the error.
     return_code: Option<i32>,
+    /// Optional context of the error.
     context: Option<String>,
+    /// Source of the error.
     #[source]
     source: std::io::Error,
   },
@@ -38,43 +101,86 @@ impl From<std::io::Error> for RandomAccessError {
   }
 }
 
-/// The `RandomAccess` trait allows for reading from and writing to a
+/// Interface for reading from, writing to and deleting from a
 /// randomly accessible storage of bytes.
 #[async_trait::async_trait]
 pub trait RandomAccess {
-  /// Write bytes at an offset to the backend.
+  /// Write bytes of `data` at an `offset` to the backend.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::OutOfBounds] if the backend has
+  /// a maximum capacity that would be exceeded by the write.
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn write(
     &mut self,
     offset: u64,
     data: &[u8],
   ) -> Result<(), RandomAccessError>;
 
-  /// Read a sequence of bytes at an offset from the backend.
+  /// Read a sequence of bytes at an `offset` from the backend.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::OutOfBounds] if
+  /// [RandomAccess::len] > `offset` + `length`.
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn read(
     &mut self,
     offset: u64,
     length: u64,
   ) -> Result<Vec<u8>, RandomAccessError>;
 
-  /// Delete a sequence of bytes at an offset from the backend.
+  /// Delete a sequence of bytes of given `length` at an `offset` from the backend.
+  /// This either sets the bytes in the given slice to zeroes, or if
+  /// `offset` + `length` >= [RandomAccess::len()] is the same as
+  /// `truncate(offset)`.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::OutOfBounds] if [RandomAccess::len()] < `offset` + `length`.
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn del(
     &mut self,
     offset: u64,
     length: u64,
   ) -> Result<(), RandomAccessError>;
 
-  /// Resize the sequence of bytes, possibly discarding or zero-padding bytes
-  /// from the end.
+  /// Resize the sequence of bytes so that [RandomAccess::len()] is set to
+  /// `length`. If `length` < [RandomAccess::len()], the bytes are disregarded.
+  /// If `length` > [RandomAccess::len()], the storage is zero-padded.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::OutOfBounds] if the backend has
+  /// a maximum capacity smaller than `length`.
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn truncate(&mut self, length: u64) -> Result<(), RandomAccessError>;
 
   /// Get the size of the storage in bytes.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn len(&mut self) -> Result<u64, RandomAccessError>;
 
-  /// Whether the storage is empty.
-  /// For some storage backends it may be cheaper to calculate whether the
-  /// storage is empty than to calculate the length.
+  /// Whether the storage is empty. For some storage backends it may be
+  /// cheaper to calculate whether the storage is empty than to calculate the
+  /// length.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn is_empty(&mut self) -> Result<bool, RandomAccessError>;
 
   /// Flush buffered data on the underlying storage resource.
+  ///
+  /// # Errors
+  ///
+  /// * [RandomAccessError::IO] if an unexpected IO error occurred.
   async fn sync_all(&mut self) -> Result<(), RandomAccessError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub trait RandomAccess {
   async fn truncate(&mut self, length: u64) -> Result<(), Self::Error>;
 
   /// Get the size of the storage in bytes.
-  async fn len(&self) -> Result<u64, Self::Error>;
+  async fn len(&mut self) -> Result<u64, Self::Error>;
 
   /// Whether the storage is empty.
   /// For some storage backends it may be cheaper to calculate whether the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,42 +3,72 @@
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
 
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RandomAccessError {
+  #[error("Offset out of bounds. {length:?} < {offset:?}")]
+  OffsetOutOfBounds { offset: u64, length: u64 },
+  #[error("Range out of bounds. {length:?} < {start:?}..{end:?}")]
+  RangeOutOfBounds { start: u64, end: u64, length: u64 },
+  #[error("Unrecoverable input/output error occured.{}{}",
+          .return_code.as_ref().map_or_else(String::new, |rc| format!(" Return code: {}.", rc)),
+          .context.as_ref().map_or_else(String::new, |ctx| format!(" Context: {}.", ctx)))]
+  IO {
+    return_code: Option<i32>,
+    context: Option<String>,
+    #[source]
+    source: std::io::Error,
+  },
+}
+
+impl From<std::io::Error> for RandomAccessError {
+  fn from(err: std::io::Error) -> Self {
+    Self::IO {
+      return_code: None,
+      context: None,
+      source: err,
+    }
+  }
+}
+
 /// The `RandomAccess` trait allows for reading from and writing to a
 /// randomly accessible storage of bytes.
 #[async_trait::async_trait]
 pub trait RandomAccess {
-  /// An error.
-  type Error;
-
   /// Write bytes at an offset to the backend.
   async fn write(
     &mut self,
     offset: u64,
     data: &[u8],
-  ) -> Result<(), Self::Error>;
+  ) -> Result<(), RandomAccessError>;
 
   /// Read a sequence of bytes at an offset from the backend.
   async fn read(
     &mut self,
     offset: u64,
     length: u64,
-  ) -> Result<Vec<u8>, Self::Error>;
+  ) -> Result<Vec<u8>, RandomAccessError>;
 
   /// Delete a sequence of bytes at an offset from the backend.
-  async fn del(&mut self, offset: u64, length: u64) -> Result<(), Self::Error>;
+  async fn del(
+    &mut self,
+    offset: u64,
+    length: u64,
+  ) -> Result<(), RandomAccessError>;
 
   /// Resize the sequence of bytes, possibly discarding or zero-padding bytes
   /// from the end.
-  async fn truncate(&mut self, length: u64) -> Result<(), Self::Error>;
+  async fn truncate(&mut self, length: u64) -> Result<(), RandomAccessError>;
 
   /// Get the size of the storage in bytes.
-  async fn len(&mut self) -> Result<u64, Self::Error>;
+  async fn len(&mut self) -> Result<u64, RandomAccessError>;
 
   /// Whether the storage is empty.
   /// For some storage backends it may be cheaper to calculate whether the
   /// storage is empty than to calculate the length.
-  async fn is_empty(&mut self) -> Result<bool, Self::Error>;
+  async fn is_empty(&mut self) -> Result<bool, RandomAccessError>;
 
   /// Flush buffered data on the underlying storage resource.
-  async fn sync_all(&mut self) -> Result<(), Self::Error>;
+  async fn sync_all(&mut self) -> Result<(), RandomAccessError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,16 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum RandomAccessError {
-  #[error("Offset out of bounds. {length:?} < {offset:?}")]
-  OffsetOutOfBounds { offset: u64, length: u64 },
-  #[error("Range out of bounds. {length:?} < {start:?}..{end:?}")]
-  RangeOutOfBounds { start: u64, end: u64, length: u64 },
+  #[error("{} out of bounds. {} < {}{}",
+          .end.as_ref().map_or_else(|| "Offset", |_| "Range"),
+          .length,
+          .offset,
+          .end.as_ref().map_or_else(String::new, |end| format!("..{}", end)))]
+  OutOfBounds {
+    offset: u64,
+    end: Option<u64>,
+    length: u64,
+  },
   #[error("Unrecoverable input/output error occured.{}{}",
           .return_code.as_ref().map_or_else(String::new, |rc| format!(" Return code: {}.", rc)),
           .context.as_ref().map_or_else(String::new, |ctx| format!(" Context: {}.", ctx)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,6 @@ pub trait RandomAccess {
     length: u64,
   ) -> Result<Vec<u8>, Self::Error>;
 
-  /// Read a sequence of bytes at an offset from the backend.
-  async fn read_to_writer(
-    &mut self,
-    offset: u64,
-    length: u64,
-    buf: &mut (impl futures_io::AsyncWrite + Send),
-  ) -> Result<(), Self::Error>;
-
   /// Delete a sequence of bytes at an offset from the backend.
   async fn del(&mut self, offset: u64, length: u64) -> Result<(), Self::Error>;
 


### PR DESCRIPTION
Includes changes needed for full implementations of random-access-disk and random-access-memory.

## Fix missing `&mut` in `len()` causing Sync compilation problems

When attempting to compile code that calls `len()` compilation fails with Sync problems. This likely got overlooked because no project yet used the function. Note that `&mut` seems unnecessary but is not: similarly `is_empty()` has also always been `&mut`.

## Remove `read_to_writer()`

This method was the reason for `futures` dependency in the crate, but the method was also unimplemented in random-access-disk and random-access-memory. Instead of keeping it in the interface without any known implementors, I propose to just remove it (alongside the futures dependency). This method can be re-added once there is a valid use case for it.

## Add `RandomAccessError` using `thiserror`

Instead of using `anyhow` in a library, follow Rust best practices in giving the library users a detailed error type via `thiserror`.

## Bump edition from 2018 to 2021

Because this is a breaking change, this is a good place to also bump the rust edition to the latest.

## Comprehensive documentation

Move (broken) documentation from README to lib.rs and document more thoroughly the error conditions for each method.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
random-access-memory PR: https://github.com/datrs/random-access-memory/pull/37
random-access-disk PR: https://github.com/datrs/random-access-disk/pull/48

## Semver Changes
5.0.0 should be the next release